### PR TITLE
Load DB config from env

### DIFF
--- a/Examen Final.2025/README.md
+++ b/Examen Final.2025/README.md
@@ -19,6 +19,8 @@ Utilisation des API et AJAX
 ├─ api/                   # Endpoints API (e.g. search.php, deleteOrderAjax.php, deleteOldOrders.php)
 ├─ config/
 │   └─ config.php         # Configuration de la base de données et des sessions
+│                         # Peut lire DB_HOST, DB_NAME, DB_USER et DB_PASS
+│                         # depuis les variables d'environnement
 ├─ controllers/           # Contrôleurs pour gérer la logique métier
 │   ├─ AdminController.php
 │   ├─ ArticlesController.php

--- a/Examen Final.2025/config/config.php
+++ b/Examen Final.2025/config/config.php
@@ -1,10 +1,17 @@
 <?php
 if (!defined('DB_HOST')) {
-    define("DB_HOST", 'db.3wa.io');
-    define("DB_NAME", 'chokbengbouneric_Final');
-    define("DB_USER", 'chokbengbouneric');
-    define("DB_PASS", '807095bdc113fa97c1ee59cc137fd29e');
+    define('DB_HOST', getenv('DB_HOST') ?: 'db.3wa.io');
 }
-    define('SECURE_SESSION', true);
-    define('SESSION_LIFETIME', 3600);
+if (!defined('DB_NAME')) {
+    define('DB_NAME', getenv('DB_NAME') ?: 'chokbengbouneric_Final');
+}
+if (!defined('DB_USER')) {
+    define('DB_USER', getenv('DB_USER') ?: 'chokbengbouneric');
+}
+if (!defined('DB_PASS')) {
+    define('DB_PASS', getenv('DB_PASS') ?: '807095bdc113fa97c1ee59cc137fd29e');
+}
+
+define('SECURE_SESSION', true);
+define('SESSION_LIFETIME', 3600);
 ?>

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Utilisation des API et AJAX
 ├─ api/                   # Endpoints API (e.g. search.php, deleteOrderAjax.php, deleteOldOrders.php)
 ├─ config/
 │   └─ config.php         # Configuration de la base de données et des sessions
+│                         # Peut lire DB_HOST, DB_NAME, DB_USER et DB_PASS
+│                         # depuis les variables d'environnement
 ├─ controllers/           # Contrôleurs pour gérer la logique métier
 │   ├─ AdminController.php
 │   ├─ ArticlesController.php


### PR DESCRIPTION
## Summary
- allow configuring database credentials via environment variables
- document the new behaviour in both READMEs

## Testing
- `php -l 'Examen Final.2025/config/config.php'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d4348f74833096a3fddd7600b802