### PR TITLE
Fix user registration lookup bug

### DIFF
--- a/Examen Final.2025/models/Users.php
+++ b/Examen Final.2025/models/Users.php
@@ -53,6 +53,38 @@ class Users {
         $query->execute([':username' => $username]);
         return $query->fetch();
     }
+
+    // Vérifie s'il existe déjà un utilisateur avec cet email ou ce nom d'utilisateur
+    public function getUserByEmailOrUsername($email, $username) {
+        $query = $this->db->prepare("SELECT * FROM users WHERE email = :email OR username = :username LIMIT 1");
+        $query->execute([
+            ':email' => $email,
+            ':username' => $username
+        ]);
+        return $query->fetch();
+    }
+
+    // Crée un nouvel utilisateur avec un rôle par défaut 'user'
+    public function createUser($firstname, $lastname, $username, $email, $password, $address, $city, $zipcode, $country) {
+        try {
+            $query = "INSERT INTO users (firstname, lastname, username, email, password, address, city, zipcode, id_countries, role, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'user', NOW())";
+            $stmt = $this->db->prepare($query);
+            return $stmt->execute([
+                $firstname,
+                $lastname,
+                $username,
+                $email,
+                $password,
+                $address,
+                $city,
+                $zipcode,
+                $country
+            ]);
+        } catch (\PDOException $e) {
+            error_log("Erreur createUser: " . $e->getMessage());
+            return false;
+        }
+    }
     
     // Mettre à jour les informations de l'utilisateur (sauf le mot de passe)
     public function updateUser($id, $data) {


### PR DESCRIPTION
## Summary
- add `getUserByEmailOrUsername` to search users by email or username
- add `createUser` helper to insert new users

## Testing
- `php -l models/Users.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849d9d079408330a98a7209e3161949